### PR TITLE
Remove redundant strings from ParentApp messages.pot

### DIFF
--- a/translations/parent_app/en/messages.pot
+++ b/translations/parent_app/en/messages.pot
@@ -205,11 +205,6 @@ msgstr ""
 
 #. type=template
 msgctxt "template"
-msgid "_count"
-msgstr ""
-
-#. type=template
-msgctxt "template"
 msgid "Give me quick parenting tips"
 msgstr ""
 
@@ -415,14 +410,6 @@ msgstr ""
 #. The string @local.threshold should not be translated.
 msgctxt "template"
 msgid "You selected @local.threshold or more"
-msgstr ""
-
-#. type=template
-#. The following strings should not be translated: 
-#.      @local.slider_1
-#.      @local.slider_2
-msgctxt "template"
-msgid "@local.slider_1==\"no_value\" || @local.slider_2 ==\"no_value\""
 msgstr ""
 
 #. type=template
@@ -2443,16 +2430,6 @@ msgstr ""
 
 #. type=template
 msgctxt "template"
-msgid "_tracker"
-msgstr ""
-
-#. type=template
-msgctxt "template"
-msgid "_final"
-msgstr ""
-
-#. type=template
-msgctxt "template"
 msgid "Let's talk about how your home practice went this week."
 msgstr ""
 
@@ -2464,11 +2441,6 @@ msgstr ""
 #. type=template
 msgctxt "template"
 msgid "Well done for exploring solutions to your challenges. Go try them out. Your relationship with your teen will get stronger and stronger!"
-msgstr ""
-
-#. type=template
-msgctxt "template"
-msgid "_hp_challenge"
 msgstr ""
 
 #. type=template
@@ -2843,11 +2815,6 @@ msgstr ""
 
 #. type=template
 msgctxt "template"
-msgid "**bold text** and _italic text_ with markdown"
-msgstr ""
-
-#. type=template
-msgctxt "template"
 msgid "Welcome Back!"
 msgstr ""
 
@@ -2859,34 +2826,6 @@ msgstr ""
 #. type=template
 msgctxt "template"
 msgid "Show Popup"
-msgstr ""
-
-#. type=template
-msgctxt "template"
-msgid "set raw value"
-msgstr ""
-
-#. type=template
-#. The string `@fields.example_raw should not be translated.
-msgctxt "template"
-msgid "raw: `@fields.example_raw`"
-msgstr ""
-
-#. type=template
-#. The string @fields.example_raw should not be translated.
-msgctxt "template"
-msgid "parsed: @fields.example_raw"
-msgstr ""
-
-#. type=template
-#. The following strings should not be translated: 
-#.      `@fields.example_raw
-#.      @fields.example_raw
-msgctxt "template"
-msgid ""
-"will not work when combined:\n"
-"raw: `@fields.example_raw`\n"
-"parsed: @fields.example_raw"
 msgstr ""
 
 #. type=template
@@ -4103,11 +4042,6 @@ msgstr ""
 
 #. type=template
 msgctxt "template"
-msgid "checkbox_tracker"
-msgstr ""
-
-#. type=template
-msgctxt "template"
 msgid "Are there teens in your family?"
 msgstr ""
 
@@ -4416,34 +4350,6 @@ msgid "Babies"
 msgstr ""
 
 #. type=template
-#. The following strings should not be translated: 
-#.      @local.adults_word
-#.      @global.adult_age_bracket
-msgctxt "template"
-msgid "@local.adults_word (@global.adult_age_bracket)"
-msgstr ""
-
-#. type=template
-#. The following strings should not be translated: 
-#.      @local.teens_word
-#.      @global.teen_age_bracket
-msgctxt "template"
-msgid "@local.teens_word (@global.teen_age_bracket)"
-msgstr ""
-
-#. type=template
-#. The string @local.children_word should not be translated.
-msgctxt "template"
-msgid "@local.children_word (2-9)"
-msgstr ""
-
-#. type=template
-#. The string @local.babies_word should not be translated.
-msgctxt "template"
-msgid "@local.babies_word (0-2)"
-msgstr ""
-
-#. type=template
 msgctxt "template"
 msgid "How many people are in your household?"
 msgstr ""
@@ -4660,11 +4566,6 @@ msgstr ""
 #. type=template
 msgctxt "template"
 msgid "Let's think of ways to spend one-on-one time with your teen."
-msgstr ""
-
-#. type=template
-msgctxt "template"
-msgid "w_1on1_question_a"
 msgstr ""
 
 #. type=template
@@ -9408,11 +9309,6 @@ msgid ""
 msgstr ""
 
 #. type=global
-msgctxt "global"
-msgid "fef8eebc2ac1817a"
-msgstr ""
-
-#. type=global
 #. The string @global.parent_app should not be translated.
 msgctxt "global"
 msgid "Your @global.parent_app Code"
@@ -9512,16 +9408,6 @@ msgstr ""
 #. type=global
 msgctxt "global"
 msgid "Sending this message requires internet access. To limit data use, send this message when on WiFi."
-msgstr ""
-
-#. type=global
-msgctxt "global"
-msgid "10-17"
-msgstr ""
-
-#. type=global
-msgctxt "global"
-msgid "18+"
 msgstr ""
 
 #. type=global


### PR DESCRIPTION
I noticed in Crowdin that some strings were present but should not have been. I deleted these in the spreadsheets and recreated the .json and .pot file. 